### PR TITLE
Criadas as validações de inserção e consertados alguns testes de inserção

### DIFF
--- a/src/main/java/org/jabref/model/entry/BibEntry.java
+++ b/src/main/java/org/jabref/model/entry/BibEntry.java
@@ -2,6 +2,7 @@ package org.jabref.model.entry;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -400,7 +402,54 @@ public class BibEntry implements Cloneable {
         Objects.requireNonNull(value, "field value must not be null");
 
         String fieldName = toLowerCase(name);
-
+        
+        //  Validacao do ano
+        //      Se o ano for invalido, o substitui pelo ano atual
+        if (fieldName.equals("year")) {
+            int ano = Integer.parseInt(value);
+            int min = 1800;
+            int max = GregorianCalendar.getInstance().get(GregorianCalendar.YEAR);
+            
+            //  Deve ser uma string com 4 caracteres
+            if (value.length() != 4) {
+                return setField("year", Integer.toString(max));
+            }
+            
+            char[] charvalue = value.toCharArray();
+            
+            //  Todos os caracteres devem ser numeros
+            if (!Character.isDigit(charvalue[0]) || !Character.isDigit(charvalue[1]) || !Character.isDigit(charvalue[2]) || !Character.isDigit(charvalue[3])) {
+                return setField("year", Integer.toString(max));
+            }
+            
+            //  O ano deve estar entre 1800 e o ano atual
+            if (ano < min || ano > max) {
+                return setField("year", Integer.toString(max));
+            }
+        }
+        //  Validacao da chave bibtex
+        //      Se a chave for invalida, a substitui por uma string aleatoria
+        if (fieldName.equals("bibtexkey")) {
+            char[] chave = value.toCharArray();
+            //  Se a chave tiver menos que 2 caracteres ou comecar com um numero, ela eh invalida
+            if (value.length() < 2 || Character.isDigit(chave[0])) {
+                
+                //  Cria uma string aleatoria com o prefixo bk (BibtexKey)
+                String aux = "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890";
+                StringBuilder sb = new StringBuilder();
+                Random rnd = new Random();
+                while (sb.length() < 8) {
+                    int indice = (int) (rnd.nextFloat() * aux.length());
+                    sb.append(aux.charAt(indice));
+                }
+                String rndstr = sb.toString();
+                String validBibtexKey = "bk".concat(rndstr);
+                
+                //  Adiciona a string aleatoria
+                return setField("bibtexkey", validBibtexKey);
+            }
+        }
+        
         if (value.isEmpty()) {
             return clearField(fieldName);
         }

--- a/src/test/java/org/jabref/es2/BibtexNewEntryTest.java
+++ b/src/test/java/org/jabref/es2/BibtexNewEntryTest.java
@@ -200,7 +200,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("article");
         
         be.setField("author", null);
-        Assert.fail();
+        fail();
     }
     
     @Test(expected = NullPointerException.class)
@@ -208,7 +208,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("article");
         
         be.setField("title", null);
-        Assert.fail();
+        fail();
     }
     
     @Test(expected = NullPointerException.class)
@@ -216,7 +216,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("article");
         
         be.setField("journal", null);
-        Assert.fail();
+        fail();
     }
     
     @Test(expected = NullPointerException.class)
@@ -224,7 +224,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("article");
         
         be.setField("year", null);
-        Assert.fail();
+        fail();
     }
     
     @Test(expected = NullPointerException.class)
@@ -232,7 +232,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("article");
         
         be.setField("bibtexkey", null);
-        Assert.fail();
+        fail();
     }
     
     //          Livros
@@ -241,7 +241,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("book");
         
         be.setField("author", null);
-        Assert.fail();
+        fail();
     }
     
     @Test(expected = NullPointerException.class)
@@ -249,7 +249,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("book");
         
         be.setField("title", null);
-        Assert.fail();
+        fail();
     }
     
     @Test(expected = NullPointerException.class)
@@ -257,7 +257,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("book");
         
         be.setField("journal", null);
-        Assert.fail();
+        fail();
     }
     
     @Test(expected = NullPointerException.class)
@@ -265,7 +265,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("book");
         
         be.setField("year", null);
-        Assert.fail();
+        fail();
     }
     
     @Test(expected = NullPointerException.class)
@@ -273,7 +273,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("book");
         
         be.setField("bibtexkey", null);
-        Assert.fail();
+        fail();
     }
     
     @Test(expected = NullPointerException.class)
@@ -281,7 +281,7 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("book");
         
         be.setField("publisher", null);
-        Assert.fail();
+        fail();
     }
     
     @Test(expected = NullPointerException.class)
@@ -289,6 +289,6 @@ public class BibtexNewEntryTest {
         BibEntry be = new BibEntry("book");
         
         be.setField("editor", null);
-        Assert.fail();
+        fail();
     }
 }


### PR DESCRIPTION
Validações do campo "year":
Ano deve estar entre 1800 e o ano atual. Se não estiver, o programa troca para o ano atual.

Validações do campo "bibtexkey":
A chave deve ter pelo menos 2 caracteres e não pode começar com número. Quando a chave for inválida, o programa troca por uma string aleatória começada com "bk"

Acertos nos testes:
O fail estava incorreto. Acabei dando commit com uma versão desatualizada e que não funcionava, pois algumas declarações se perderam. Preferi fazer do jeito simples, apenas com o fail(), ao invés de redeclarar o que havia perdido.